### PR TITLE
Use `@text-color` as color for highlighting links

### DIFF
--- a/styles/code-links.less
+++ b/styles/code-links.less
@@ -11,6 +11,6 @@ body.code-links-visible atom-text-editor::shadow {
         // regions are not normally clickable and have a z-index of -1.
         // 1 seems to work, but I don't know if that might change later.
         z-index: 1;
-        border-bottom: thin solid blue;
+        border-bottom: thin solid @text-color;
     }
 }


### PR DESCRIPTION
This patch replaces horrible `blue` color with theme `text-color`.
It's gonna looks perfect with every theme:
![](https://cloud.githubusercontent.com/assets/3505878/7448540/26ef898a-f225-11e4-80bf-e1a48af750ca.png)
![](https://cloud.githubusercontent.com/assets/3505878/7448541/2dacbb94-f225-11e4-9f95-3151875ba417.png)
![](https://cloud.githubusercontent.com/assets/3505878/7448542/32205c3a-f225-11e4-8ffc-75b07b3b5ba0.png)
