### PR TITLE
Use 'keyup' event to detect the active state

### DIFF
--- a/lib/code-links.js
+++ b/lib/code-links.js
@@ -80,6 +80,12 @@ module.exports = {
                   active = [17, 18, 91].indexOf(e.which) === -1;
                 }
             });
+            window.addEventListener('blur', () => {
+                let mode = atom.config.get('code-links.displayMode');
+                if (mode === 'modifier') {
+                    active = false;
+                }
+            });
         }));
 
         atom.commands.add('atom-text-editor', 'code-links:tmp-show-links', (e) => {

--- a/lib/code-links.js
+++ b/lib/code-links.js
@@ -56,6 +56,7 @@ module.exports = {
                 document.body.classList.add(`code-links-${modifier}`);
             }
         }));
+
         this.subs.add(atom.config.observe('code-links.displayMode', (mode) => {
             if (mode === 'always') {
                 document.body.classList.add('code-links-visible');
@@ -70,8 +71,18 @@ module.exports = {
                 editor.onDidSave(this.processEditor.bind(this, editor))
             );
             this.setupClickHandler(editor);
-            this.defineHideListener(editor);
         }));
+
+        this.subs.add(window, 'keyup blur', (e) => {
+          let mode = atom.config.get('code-links.displayMode');
+          if (mode === 'modifier') {
+            // check for released modifier keys (ctrl, alt, meta)
+            if (e.type === 'keyup' && [17, 18, 91].indexOf(e.which) === -1) {
+              return
+            }
+            this.hideLinks();
+          }
+        });
 
         atom.commands.add('atom-text-editor', 'code-links:tmp-show-links', (e) => {
             // Don't interfere with any other keybindings.
@@ -168,21 +179,6 @@ module.exports = {
             }
         });
     },
-    defineHideListener(editor) {
-      // check for released modifier keys (ctrl, alt, meta)
-      atom.views.getView(editor).addEventListener('keyup', (e) => {
-          let mode = atom.config.get('code-links.displayMode');
-          if (mode === 'modifier' && [17, 18, 91].indexOf(e.which) > -1) {
-              this.hideLinks();
-          }
-      });
-      window.addEventListener('blur', () => {
-          let mode = atom.config.get('code-links.displayMode');
-          if (mode === 'modifier') {
-              this.hideLinks();
-          }
-      });
-    },
     handleClick(editor) {
 
         // ctrl+click creates multiple cursors. This will remove all but the
@@ -262,5 +258,5 @@ module.exports = {
     },
     serialize() {
         return {};
-    },
+    }
 };

--- a/lib/code-links.js
+++ b/lib/code-links.js
@@ -65,17 +65,23 @@ module.exports = {
             }
         }));
 
+        var active = false;
         this.subs.add(atom.workspace.observeTextEditors((editor) => {
             this.processEditor(editor);
             this.subs.add(
                 editor.onDidSave(this.processEditor.bind(this, editor))
             );
             this.setupClickHandler(editor);
+
+            // check for released modifier keys: [ctrl, alt, meta]
+            atom.views.getView(editor).addEventListener('keyup', (e) => {
+                let mode = atom.config.get('code-links.displayMode');
+                if (mode === 'modifier') {
+                  active = [17, 18, 91].indexOf(e.which) === -1;
+                }
+            });
         }));
 
-        // I had trouble detecting keyup for the modifier key, so this relies on
-        // the keyboard's repeat rate to keep the links visible.
-        let timer;
         atom.commands.add('atom-text-editor', 'code-links:tmp-show-links', (e) => {
             // Don't interfere with any other keybindings.
             e.abortKeyBinding();
@@ -85,16 +91,19 @@ module.exports = {
                 return;
             }
 
-            if (timer) {
-                clearTimeout(timer);
-            } else {
-                this.showLinks();
-            }
-            timer = setTimeout(() => {
-                timer = undefined;
-                this.hideLinks();
-            }, 500);
+            this.showLinks();
+            active = true
+
+            detectActive.call(this);
         });
+
+        // recursive state check of the modifier keys
+        function detectActive() {
+            if (active) {
+                return setTimeout(detectActive.bind(this), 500)
+            }
+            this.hideLinks();
+        }
     },
     showLinks() {
         document.body.classList.add('code-links-visible');

--- a/lib/code-links.js
+++ b/lib/code-links.js
@@ -55,7 +55,6 @@ module.exports = {
             if (mode === 'modifier') {
                 document.body.classList.add(`code-links-${modifier}`);
             }
-
         }));
         this.subs.add(atom.config.observe('code-links.displayMode', (mode) => {
             if (mode === 'always') {
@@ -65,27 +64,13 @@ module.exports = {
             }
         }));
 
-        var active = false;
         this.subs.add(atom.workspace.observeTextEditors((editor) => {
             this.processEditor(editor);
             this.subs.add(
                 editor.onDidSave(this.processEditor.bind(this, editor))
             );
             this.setupClickHandler(editor);
-
-            // check for released modifier keys: [ctrl, alt, meta]
-            atom.views.getView(editor).addEventListener('keyup', (e) => {
-                let mode = atom.config.get('code-links.displayMode');
-                if (mode === 'modifier') {
-                  active = [17, 18, 91].indexOf(e.which) === -1;
-                }
-            });
-            window.addEventListener('blur', () => {
-                let mode = atom.config.get('code-links.displayMode');
-                if (mode === 'modifier') {
-                    active = false;
-                }
-            });
+            this.defineHideListener(editor);
         }));
 
         atom.commands.add('atom-text-editor', 'code-links:tmp-show-links', (e) => {
@@ -96,20 +81,8 @@ module.exports = {
             if (mode === 'always') {
                 return;
             }
-
             this.showLinks();
-            active = true
-
-            detectActive.call(this);
         });
-
-        // recursive state check of the modifier keys
-        function detectActive() {
-            if (active) {
-                return setTimeout(detectActive.bind(this), 500)
-            }
-            this.hideLinks();
-        }
     },
     showLinks() {
         document.body.classList.add('code-links-visible');
@@ -194,6 +167,21 @@ module.exports = {
                 this.handleClick(editor);
             }
         });
+    },
+    defineHideListener(editor) {
+      // check for released modifier keys (ctrl, alt, meta)
+      atom.views.getView(editor).addEventListener('keyup', (e) => {
+          let mode = atom.config.get('code-links.displayMode');
+          if (mode === 'modifier' && [17, 18, 91].indexOf(e.which) > -1) {
+              this.hideLinks();
+          }
+      });
+      window.addEventListener('blur', () => {
+          let mode = atom.config.get('code-links.displayMode');
+          if (mode === 'modifier') {
+              this.hideLinks();
+          }
+      });
     },
     handleClick(editor) {
 

--- a/styles/code-links.less
+++ b/styles/code-links.less
@@ -11,6 +11,8 @@ body.code-links-visible atom-text-editor::shadow {
         // regions are not normally clickable and have a z-index of -1.
         // 1 seems to work, but I don't know if that might change later.
         z-index: 1;
+        // use common link style indicators
         border-bottom: thin solid @text-color;
+        cursor: pointer;
     }
 }


### PR DESCRIPTION
At least on Linux there was an issue with detecting the active state by relying on the keyboard repeat rate. The highlighted links were just temporary visible for the first 500ms and then disappeared although the modifier key kept being pressed. Works on my system so far - do you still have troubles on yours using the event listeners ?
