### PR TITLE
Links clickable after timeout

### DIFF
--- a/styles/code-links.less
+++ b/styles/code-links.less
@@ -6,11 +6,17 @@
 
 body.code-links-visible atom-text-editor::shadow {
     .code-links .region {
+        border-bottom: thin solid @text-color;
+    }
+}
+
+// Added this to make links clickable also after timer hides them
+body atom-text-editor::shadow {
+    .code-links .region {
         // Needs to be clickable
         pointer-events: auto;
         // regions are not normally clickable and have a z-index of -1.
         // 1 seems to work, but I don't know if that might change later.
         z-index: 1;
-        border-bottom: thin solid @text-color;
     }
 }


### PR DESCRIPTION
On Linux the links are not clickable after the timer runs out.

With this change, the links are always clickable (you still have to press the modifier, of course). The change only affects the stylesheet and does not modify the appearance of the links.

(Sorry about the duplicate pull request).
