### PR TITLE
Map command key as cmd

### DIFF
--- a/keymaps/code-links.cson
+++ b/keymaps/code-links.cson
@@ -11,5 +11,5 @@
 }
 
 'body.code-links-meta atom-text-editor': {
-  'command': 'code-links:tmp-show-links'
+  'cmd': 'code-links:tmp-show-links'
 }


### PR DESCRIPTION
`Command` doesn't work, at least on OSX.
