### PR TITLE
Add pointer class to cursor

### DIFF
--- a/styles/code-links.less
+++ b/styles/code-links.less
@@ -12,5 +12,6 @@ body.code-links-visible atom-text-editor::shadow {
         // 1 seems to work, but I don't know if that might change later.
         z-index: 1;
         border-bottom: thin solid @text-color;
+        cursor: pointer;
     }
 }


### PR DESCRIPTION
I think it is more user-friendly to turn the cursor into a **pointer** over a lynk to let the user know that the element its clickable, apart from the underlined class.
